### PR TITLE
Fix rotation for McpeMovePlayer

### DIFF
--- a/api/src/main/java/com/voxelwind/api/util/Rotation.java
+++ b/api/src/main/java/com/voxelwind/api/util/Rotation.java
@@ -2,10 +2,12 @@ package com.voxelwind.api.util;
 
 import com.flowpowered.math.vector.Vector3f;
 import com.google.common.base.Preconditions;
+import lombok.Builder;
 
 /**
  * This class represents a rotation. Pocket Edition uses degrees to measure angles. This class is immutable.
  */
+@Builder
 public final class Rotation {
     public static final Rotation ZERO = new Rotation(0f, 0f, 0f);
 

--- a/server/src/main/java/com/voxelwind/server/network/mcpe/packets/McpeMovePlayer.java
+++ b/server/src/main/java/com/voxelwind/server/network/mcpe/packets/McpeMovePlayer.java
@@ -19,7 +19,10 @@ public class McpeMovePlayer implements NetworkPackage {
     public void decode(ByteBuf buffer) {
         entityId = buffer.readLong();
         position = McpeUtil.readVector3f(buffer);
-        rotation = McpeUtil.readRotation(buffer);
+        rotation = Rotation.builder()
+                .yaw(buffer.readFloat())
+                .headYaw(buffer.readFloat())
+                .pitch(buffer.readFloat()).build();
         mode = buffer.readBoolean();
         onGround = buffer.readBoolean();
     }
@@ -29,6 +32,9 @@ public class McpeMovePlayer implements NetworkPackage {
         buffer.writeLong(entityId);
         McpeUtil.writeVector3f(buffer, position);
         McpeUtil.writeRotation(buffer, rotation);
+        buffer.writeFloat(rotation.getYaw());
+        buffer.writeFloat(rotation.getHeadYaw());
+        buffer.writeFloat(rotation.getPitch());
         buffer.writeBoolean(mode);
         buffer.writeBoolean(onGround);
     }


### PR DESCRIPTION
Currently, the readPosition reads it like this:

| Type | Name | 
|:-----|:-------| 
| **Byte** | Pitch |
| **Byte** | Yaw |
| **Byte** | HeadYaw |

This is good for the `Move entity (clientbound)` packet. However, the `Move player (serverbound)` requires to have `yaw,headYaw,pitch` in `floats`. So both the order and type is wrong if you do readRotation for PacketMovePlayer
![https://fs.matsv.nl/media?id=16jdj8lij3h.png](https://fs.matsv.nl/images/16jdj8lij3h.png) ![https://fs.matsv.nl/media?id=rcfw0qjrfp3.png](https://fs.matsv.nl/images/rcfw0qjrfp3.png)

I simply added a Builder annotation to not have to store 3 local variables for the correct constructor order.

Feel free to close it and change it to what you like.
Source: [Yawkats documentation](https://confluence.yawk.at/display/PEPROTOCOL/Game+Packets)