### PR TITLE
Fix McpeSetTime

### DIFF
--- a/server/src/main/java/com/voxelwind/server/network/mcpe/packets/McpeSetTime.java
+++ b/server/src/main/java/com/voxelwind/server/network/mcpe/packets/McpeSetTime.java
@@ -6,18 +6,18 @@ import lombok.Data;
 
 @Data
 public class McpeSetTime implements NetworkPackage {
-    private long time;
+    private int time;
     private boolean running;
 
     @Override
     public void decode(ByteBuf buffer) {
-        time = buffer.readLong();
+        time = buffer.readInt();
         running = buffer.readBoolean();
     }
 
     @Override
     public void encode(ByteBuf buffer) {
-        buffer.writeLong(time);
+        buffer.writeInt(time);
         buffer.writeBoolean(running);
     }
 }


### PR DESCRIPTION
The time packet is documented wrongly or outdated on [Yawkat's protocol documentation](https://confluence.yawk.at/display/PEPROTOCOL/Game+Packets)

It's an integer according to [PocketMine](https://github.com/PocketMine/PocketMine-MP/blob/master/src/pocketmine/network/protocol/SetTimePacket.php), [MiNET](https://github.com/NiclasOlofsson/MiNET/blob/master/src/MiNET/MiNET/Net/MCPE%20Protocol%20Documentation.md#package-mcpe-set-time-0x08) & [Nukkit](https://github.com/Nukkit/Nukkit/blob/master/src/main/java/cn/nukkit/network/protocol/SetTimePacket.java)


**Yawkat on IRC:**
> it may have changed recently 
The docs are a few months old
