### PR TITLE
Fix Chunkradius Bug

### DIFF
--- a/server/src/main/java/com/voxelwind/server/network/session/PlayerSession.java
+++ b/server/src/main/java/com/voxelwind/server/network/session/PlayerSession.java
@@ -582,7 +582,7 @@ public class PlayerSession extends LivingEntity implements Player, InventoryObse
 
         @Override
         public void handle(McpeRequestChunkRadius packet) {
-            int radius = Math.max(5, Math.min(16, packet.getRadius()));
+            int radius = Math.min(5, Math.max(16, packet.getRadius()));
             McpeChunkRadiusUpdated updated = new McpeChunkRadiusUpdated();
             updated.setRadius(radius);
             session.sendImmediatePackage(updated);


### PR DESCRIPTION
This bug affects the radius of chunks sent to the client when they send their chunk radius configuration. It maxes out at 5 which is wrong. It should max out at 16 like this fix does.